### PR TITLE
support for homozygous INDELs without separator

### DIFF
--- a/src/GenomeMap.js
+++ b/src/GenomeMap.js
@@ -67,14 +67,24 @@ export default class GenomeMap {
     return { marker: chromosome.markers[markerIndex], markerIndex };
   }
 
-  markerByName(markerName) {	/* this method could probably be optimized for faster loading (calling it again and again takes really long with numerous markers)*/
+  markerByName(markerName, markerIndexesByNamesAndChromosomes) {
     let found = -1;
-    this.chromosomes.forEach((chromosome, idx) => {
-      const markerIndex = chromosome.markers.map(m => m.name).indexOf(markerName);
-      if (markerIndex !== -1) {
-        found = { chromosome: idx, markerIndex };
-      }
-    });
+
+	if (markerIndexesByNamesAndChromosomes != null)
+		for (var chrIdx in markerIndexesByNamesAndChromosomes) {
+			const markerIndex = markerIndexesByNamesAndChromosomes[chrIdx].indexOf(markerName);
+			if (markerIndex !== -1) {
+	        	found = { chromosome: chrIdx, markerIndex };
+				break;
+	    	}
+		}
+	else
+	    this.chromosomes.forEach((chromosome, idx) => {
+	      const markerIndex = chromosome.markers.map(m => m.name).indexOf(markerName);
+	      if (markerIndex !== -1) {
+	        found = { chromosome: idx, markerIndex };
+	      }
+	    });
 
     return found;
   }

--- a/src/GenomeMap.js
+++ b/src/GenomeMap.js
@@ -67,7 +67,7 @@ export default class GenomeMap {
     return { marker: chromosome.markers[markerIndex], markerIndex };
   }
 
-  markerByName(markerName) {
+  markerByName(markerName) {	/* this method could probably be optimized for faster loading (calling it again and again takes really long with numerous markers)*/
     let found = -1;
     this.chromosomes.forEach((chromosome, idx) => {
       const markerIndex = chromosome.markers.map(m => m.name).indexOf(markerName);

--- a/src/Genotype.js
+++ b/src/Genotype.js
@@ -19,20 +19,21 @@ export default class Genotype {
     const upperCased = genotypeString.toUpperCase();
     let geno;
 
-    if (upperCased.length === 3 && !upperCased.includes(hetSeparator)) {
-      throw Error('Encounctered a string which could not be converted into a Genotype');
-    }
+//    if (upperCased.length === 3 && !upperCased.includes(hetSeparator)) {
+//      throw Error('Encountered a string which could not be converted into a Genotype');
+//    }
 
     if (upperCased === '-' || upperCased === 'NN' || upperCased === 'N/N' || (!upperCased || upperCased.length === 0)) {
       geno = new Genotype('', '', true);
     } else if (upperCased.length === 1) {
       geno = new Genotype(upperCased, upperCased, true);
-    } else if (upperCased.length === 2) {
+    } else if (upperCased.length === 2 && (hetSeparator == null || hetSeparator == "")) {
       geno = new Genotype(upperCased[0], upperCased[1], upperCased[0] === upperCased[1]);
     } else if (upperCased.includes(hetSeparator)) {
       const alleles = upperCased.split(hetSeparator);
       geno = new Genotype(alleles[0], alleles[1], alleles[0] === alleles[1]);
-    }
+    } else	// homozygous with multi-nucleic allele (INDEL?) 
+		geno = new Genotype(upperCased, upperCased, true);
 
     return geno;
   }

--- a/src/GenotypeImporter.js
+++ b/src/GenotypeImporter.js
@@ -14,6 +14,8 @@ export default class GenotypeImporter {
     this.genomeMap = genomeMap;
     this.markerIndices = new Map();
     this.germplasmList = [];
+	this.processedLines;
+	this.totalLineCount;
   }
 
   getState(genoString) {
@@ -82,12 +84,20 @@ export default class GenotypeImporter {
   }
 
   parseFile(fileContents) {
+	this.processedLines = 0;
+	this.totalLineCount = 0;
     const lines = fileContents.split(/\r?\n/);
-    for (let line = 0; line < lines.length; line += 1) {
+	this.totalLineCount = lines.length;
+    for (let line = 0; line < this.totalLineCount; line += 1) {
       this.processFileLine(lines[line]);
+	  this.processedLines = line;
     }
 
     return this.germplasmList;
+  }
+
+  getImportProgressPercentage() {
+	return parseInt(this.processedLines + " / " + this.totalLineCount);
   }
 
   // In situations where a map hasn't been provided, we want to create a fake or

--- a/src/GenotypeImporter.js
+++ b/src/GenotypeImporter.js
@@ -50,7 +50,7 @@ export default class GenotypeImporter {
     return data;
   }
 
-  processFileLine(line) {
+  processFileLine(line, markerIndexesByNamesAndChromosomes) {
     if (line.startsWith('#') || (!line || line.length === 0)) {
       return;
     }
@@ -59,7 +59,7 @@ export default class GenotypeImporter {
       const markerNames = line.split('\t');
 
       markerNames.slice(1).forEach((name, idx) => {
-        const indices = this.genomeMap.markerByName(name);
+        const indices = this.genomeMap.markerByName(name, markerIndexesByNamesAndChromosomes);
         if (indices !== -1) {
           this.markerIndices.set(idx, indices);
         }
@@ -84,15 +84,23 @@ export default class GenotypeImporter {
   }
 
   parseFile(fileContents) {
+	var b4 = Date.now();
+	
+	// pre-calculating this index array once for all brings significantly faster loading
+	var markerIndexesByNamesAndChromosomes = new Array();
+	this.genomeMap.chromosomes.forEach((chromosome, idx) => {
+	  markerIndexesByNamesAndChromosomes[idx] = chromosome.markers.map(m => m.name);
+    });
+
 	this.processedLines = 0;
 	this.totalLineCount = 0;
     const lines = fileContents.split(/\r?\n/);
 	this.totalLineCount = lines.length;
     for (let line = 0; line < this.totalLineCount; line += 1) {
-      this.processFileLine(lines[line]);
+      this.processFileLine(lines[line], markerIndexesByNamesAndChromosomes);
 	  this.processedLines = line;
     }
-
+	console.log("parseFile took " + (Date.now() - b4) + "ms");
     return this.germplasmList;
   }
 

--- a/src/NucleotideColorScheme.js
+++ b/src/NucleotideColorScheme.js
@@ -48,8 +48,13 @@ export default class NucleotideColorScheme {
     });
   }
 
+  getAlleleColor(allele) {
+	let color = this.colorMap.get(allele);
+	return color == null ? this.colorMap.get("-") : color;
+  }
+
   drawGradientSquare(size, genotype, font, fontSize) {
-    const color = this.colorMap.get(genotype.allele1);
+    const color = this.getAlleleColor(genotype.allele1);
     const gradCanvas = document.createElement('canvas');
     gradCanvas.width = size;
     gradCanvas.height = size;
@@ -72,8 +77,8 @@ export default class NucleotideColorScheme {
   }
 
   drawHetSquare(size, genotype, font, fontSize) {
-    const color1 = this.colorMap.get(genotype.allele1);
-    const color2 = this.colorMap.get(genotype.allele2);
+    const color1 = this.getAlleleColor(genotype.allele1);
+    const color2 = this.getAlleleColor(genotype.allele2);
     const gradCanvas = document.createElement('canvas');
     gradCanvas.width = size;
     gradCanvas.height = size;

--- a/src/flapjack-bytes.js
+++ b/src/flapjack-bytes.js
@@ -370,6 +370,14 @@ export default function GenotypeRenderer() {
 
         genotypeCanvas.init(dataSet, colorScheme);
         genotypeCanvas.prerender();
+
+        // Tells the dom parent that Flapjack has finished loading. Allows spinners
+        // or similar to be disabled
+        sendEvent('FlapjackFinished', domParent);
+      }).catch((error) => {
+        sendEvent('FlapjackError', domParent);
+        // eslint-disable-next-line no-console
+        console.log(error);
       });
     });
     return genotypeRenderer;

--- a/src/flapjack-bytes.js
+++ b/src/flapjack-bytes.js
@@ -8,6 +8,7 @@ import DataSet from './DataSet';
 
 export default function GenotypeRenderer() {
   const genotypeRenderer = {};
+  let genotypeImporter;
 
   // Variables for referring to the genotype canvas
   let genotypeCanvas;
@@ -263,7 +264,7 @@ export default function GenotypeRenderer() {
 
           processVariantSetCall(client, `/variantsets/${matrixId}/calls`)
             .then((variantSetCalls) => {
-              const genotypeImporter = new GenotypeImporter(genomeMap);
+              genotypeImporter = new GenotypeImporter(genomeMap);
 
               if (genomeMap === undefined) {
                 genomeMap = genotypeImporter.createFakeMapFromVariantSets(variantSetCalls);
@@ -298,7 +299,7 @@ export default function GenotypeRenderer() {
     } else {
       processVariantSetCall(client, `/variantsets/${matrixId}/calls`)
         .then((variantSetCalls) => {
-          const genotypeImporter = new GenotypeImporter(genomeMap);
+          genotypeImporter = new GenotypeImporter(genomeMap);
 
           if (genomeMap === undefined) {
             genomeMap = genotypeImporter.createFakeMapFromVariantSets(variantSetCalls);
@@ -354,7 +355,7 @@ export default function GenotypeRenderer() {
       axios.get(genotypeFileURL, {}, { headers: { 'Content-Type': 'text/plain' } }).then((response) => {
         genotypeFile = response.data;
       }).then(() => {
-        const genotypeImporter = new GenotypeImporter(genomeMap);
+        genotypeImporter = new GenotypeImporter(genomeMap);
 
         if (genomeMap === undefined) {
           genomeMap = genotypeImporter.createFakeMap(genotypeFile);
@@ -440,7 +441,7 @@ export default function GenotypeRenderer() {
 
     // Then genotype data
     genotypePromise.then((result) => {
-      const genotypeImporter = new GenotypeImporter(genomeMap);
+      genotypeImporter = new GenotypeImporter(genomeMap);
 
       if (genomeMap === undefined) {
         genomeMap = genotypeImporter.createFakeMap(result);
@@ -459,6 +460,10 @@ export default function GenotypeRenderer() {
     });
 
     return genotypeRenderer;
+  };
+
+  genotypeRenderer.getRenderingProgressPercentage = function getRenderingProgressPercentage() {
+	return genotypeImporter == null ? -1 : genotypeImporter.getImportProgressPercentage();
   };
 
   return genotypeRenderer;


### PR DESCRIPTION
Changes in commit 1d00561 make FJ-Bytes show the same color matrix as the standalone version for the attached dataset (wasn't the case before)

[43327da2O6e3b3ca4__project1__2021-07-09__9variants__FLAPJACK.zip](https://github.com/cropgeeks/flapjack-bytes/files/6792471/43327da2O6e3b3ca4__project1__2021-07-09__9variants__FLAPJACK.zip)
