### PR TITLE
Add traits support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,16 +72,16 @@ deployed at: http://bioinf.hutton.ac.uk/gobii-flapjack-bytes.
 ```javascript
 var renderer = GenotypeRenderer();
 renderer.renderGenotypesBrapi({
-  domParent: "#bytes-div",  // Container to inject the canvas into
-  width: 800,  // Genotype view width
-  height: 600,   // Genotype view height
-  baseURL: this.baseUrl,    // BrAPI base URL
-  matrixId: this.callSetId,
-  mapId: this.mapId,
-  authToken: this.authToken
-  overviewWidth: 800,  // Overview width
-  overviewWidth: 200,   // Overview height
-  saveSettings: false,
+    domParent: "#bytes-div",  // Container to inject the canvas into
+    width: 800,  // Genotype view width
+    height: 600,   // Genotype view height
+    baseURL: this.baseUrl,    // BrAPI base URL
+    matrixId: this.callSetId,
+    mapId: this.mapId,
+    authToken: this.authToken
+    overviewWidth: 800,  // Overview width
+    overviewWidth: 200,   // Overview height
+    saveSettings: false,
 });
 ```
 
@@ -135,32 +135,29 @@ The HTML includes a couple of file inputs for getting the files to be loaded
 into the flapjack-bytes library.
 
 ```javascript
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 <script src="build/flapjack-bytes.js"></script>
 <script type="text/javascript">
-  $(document).ready(function(){
-    $("#submit").click(function(){
-      var renderer = GenotypeRenderer();
-      renderer.renderGenotypesFile({
-        domParent: "#canvas-holder",
-        width: null,
-        height: 600,
-        mapFileDom: "#mapfile",
-        genotypeFileDom: "#genofile",
-        phenotypeFileDom: "#phenofile",
-        overviewWidth: null,
-        overviewHeight: 200,
-        minGenotypeAutoWidth: 600,
-        minOverviewAutoWidth: 600
-      });
-      return false;
+document.addEventListener("DOMContentLoaded", function(){
+    document.getElementById("submit").addEventListener("click", function(){
+        var renderer = GenotypeRenderer();
+        renderer.renderGenotypesFile({
+            domParent: "#canvas-holder",
+            width: null,
+            height: 600,
+            mapFileDom: "#mapfile",
+            genotypeFileDom: "#genofile",
+            phenotypeFileDom: "#phenofile",
+            overviewWidth: null,
+            overviewHeight: 200,
+            minGenotypeAutoWidth: 600,
+            minOverviewAutoWidth: 600,
+            dataSetId: "MyDataSet"
+        });
+        return false;
     });
 });
 </script>
 ```
-
-Here jQuery is just used to simplify adding the event handler to the submit
-button. 
 
 The parameters are as follows:
 - `domParent`: the id of the canvas to inject the flapjack-bytes canvas into
@@ -192,18 +189,18 @@ same server that is hosting the files, or the server hosting the files has to be
 
 ```html
 <div>
-  <div>
-    <label for="mapfile">Map file:</label>
-    <input type="text" id="mapfile" name="mapfile" value="http://bioinf.hutton.ac.uk/flapjack/sample-data/tutorials/ped-ver-tutorial.map">
-  </div>
-  <div>
-    <label for="genofile">Genotype file:</label>
-    <input type="text" id="genofile" name="genofile" value="http://bioinf.hutton.ac.uk/flapjack/sample-data/tutorials/ped-ver-tutorial.dat">
-  </div>
-  <input type="submit" action="#" id="submit" name="submit" value="Submit">
+    <div>
+        <label for="mapfile">Map file:</label>
+        <input type="text" id="mapfile" name="mapfile" value="http://bioinf.hutton.ac.uk/flapjack/sample-data/tutorials/ped-ver-tutorial.map">
+    </div>
+    <div>
+        <label for="genofile">Genotype file:</label>
+        <input type="text" id="genofile" name="genofile" value="http://bioinf.hutton.ac.uk/flapjack/sample-data/tutorials/ped-ver-tutorial.dat">
+    </div>
+    <input type="submit" action="#" id="submit" name="submit" value="Submit">
 </div>
 <div id="canvas-holder">
-  <!-- Empty div that we can insert a canvas into from javascript. -->
+    <!-- Empty div that we can insert a canvas into from javascript. -->
 </div>
 ```
 
@@ -211,42 +208,26 @@ The HTML includes a couple of text inputs for getting the urls of files to be
 loaded into the flapjack-bytes library.
 
 ```javascript
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 <script src="build/flapjack-bytes.js"></script>
 <script type="text/javascript">
-  $(document).ready(function(){
-    $("#submit").click(function(){
-      var renderer = GenotypeRenderer();
-      renderer.renderGenotypesUrl({
-        domParent: "#canvas-holder",
-        width: 800,
-        height: 600,
-        mapFileURL: $('#mapfile').val(),
-        genotypeFileURL: $('#genofile').val(),
-        overviewWidth: 800,
-        overviewHeight: 200
-      });
-      return false;
+document.addEventListener("DOMContentLoaded", function(){
+    document.getElementById("submit").addEventListener("click", function(){
+        var renderer = GenotypeRenderer();
+        renderer.renderGenotypesUrl({
+            domParent: "#canvas-holder",
+            width: 800,
+            height: 600,
+            mapFileURL: $('#mapfile').val(),
+            genotypeFileURL: $('#genofile').val(),
+            phenotypeFileURL: $('#phenotype').val(),
+            overviewWidth: 800,
+            overviewHeight: 200
+            dataSetId: "MyDataSet",
+        });
+        return false;
     });
 });
 </script>
-```
-
-Here jQuery is just used to simplify adding the event handler to the submit
-button. The meat of the code is the following two lines:
-
-```javascript
-var renderer = GenotypeRenderer();
-renderer.renderGenotypesUrl({
-  domParent: "#canvas-holder",
-  width: 800,
-  height: 600,
-  mapFileURL: $('#mapfile').val(),
-  genotypeFileURL: $('#genofile').val(),
-  overviewWidth: 800,
-  overviewHeight: 200,
-  dataSetId: "MyDataSet",
-});
 ```
 
 Where the parameters are as follows:

--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ local computer, or via URL.
 - Multiple colour schemes; the default Nucleotide colour scheme, a similarity
 colour scheme where each line is coloured on a basis of its match to a user
 selectable comparison line.
-- Multiple sorting options; importing order, alphabetic or by similarity rate
+- Multiple sorting options: importing order, alphabetic, by trait or by similarity rate
 - Highlight of the line and marker under the mouse.
 - Zoomable and scrollable view of the data.
 - Genotype data overview
+- Trait values and heatmap display
 - Export the view or overview as images
 
 ## Examples
@@ -70,17 +71,17 @@ deployed at: http://bioinf.hutton.ac.uk/gobii-flapjack-bytes.
 
 ```javascript
 var renderer = GenotypeRenderer();
-renderer.renderGenotypesBrapi(
-  "#bytes-div",
-  800,  // Genotype view width
-  600,   // Genotype view height
-  this.baseUrl,    // BrAPI base URL
-  this.callSetId,
-  this.mapId,
-  this.authToken
-  800,  // Overview width
-  200,   // Overview height
-);
+renderer.renderGenotypesBrapi({
+  domParent: "#bytes-div",  // Container to inject the canvas into
+  width: 800,  // Genotype view width
+  height: 600,   // Genotype view height
+  baseURL: this.baseUrl,    // BrAPI base URL
+  matrixId: this.callSetId,
+  mapId: this.mapId,
+  authToken: this.authToken
+  overviewWidth: 800,  // Overview width
+  overviewWidth: 200,   // Overview height
+});
 ```
 
 The baseUrl, callSetId, mapId and authToken are collected on previous pages of
@@ -89,20 +90,20 @@ if you don't have map data to provide. authToken can be null if the BrAPI
 resource doesn't require authentication.
 
 The parameters are as follows:
-- the target div which we inject the library's canvas into
-- the width of the canvas the library will create 
+- `domParent`: the target div which we inject the library's canvas into
+- `width`: the width of the canvas the library will create 
     - can be set to `null` to automatically resize the canvas to fit the available width
-- the height of the canvas the library will create
-- the base url of the BrAPI server we're communicating with
-- the ID of the callSet (genotype dataset) to load from the BrAPI server
-- the ID of the map to load from the BrAPI server (or null)
-- the authentication token required to talk to the BrAPI server (or null)
-- the width of the overview the library will create
+- `height`: the height of the canvas the library will create
+- `baseURL`: the base url of the BrAPI server we're communicating with
+- `matrixId`: the ID of the callSet (genotype dataset) to load from the BrAPI server
+- `mapId`: the ID of the map to load from the BrAPI server (or null)
+- `authToken`: the authentication token required to talk to the BrAPI server (or null)
+- `overviewWidth`: the width of the overview the library will create
     - can be set to `null` to automatically resize the canvas to fit the available width
-    - If undefined, use the same width as the genotype view
-- the height of the overview the library will create (if undefined, use a default height)
-- the minimum width for the genotype view (auto-width mode only, optional)
-- the minimum height for the genotype view (auto-width mode only, optional)
+    - If left undefined, use the same width as the genotype view
+- `overviewHeight`: the height of the overview the library will create (if undefined, use a default height)
+- `minGenotypeAutoWidth`: the minimum width for the genotype view (auto-width mode only, optional)
+- `minOverviewAutoWidth`: the minimum width for the overview (auto-width mode only, optional)
 
 
 ### Local File
@@ -137,7 +138,18 @@ into the flapjack-bytes library.
   $(document).ready(function(){
     $("#submit").click(function(){
       var renderer = GenotypeRenderer();
-      renderer.renderGenotypesFile("#canvas-holder", null, 600, "#mapfile", "#genofile", null, 200, 600, 600);
+      renderer.renderGenotypesFile({
+        domParent: "#canvas-holder",
+        width: null,
+        height: 600,
+        mapFileDom: "#mapfile",
+        genotypeFileDom: "#genofile",
+        phenotypeFileDom: "#phenofile",
+        overviewWidth: null,
+        overviewHeight: 200,
+        minGenotypeAutoWidth: 600,
+        minOverviewAutoWidth: 600
+      });
       return false;
     });
 });
@@ -153,19 +165,19 @@ renderer.renderGenotypesFile("#canvas-holder", null, 600, "#mapfile", "#genofile
 ```
 
 Where the parameters are as follows:
-- the id of the canvas to inject the flapjack-bytes canvas into
-- the width of the canvas
+- `domParent`: the id of the canvas to inject the flapjack-bytes canvas into
+- `width`: the width of the canvas
     - can be set to `null` to automatically resize the canvas to fit the available width
-- the height of the canvas
-- the id of the file input for the map file (which may or may not have been
-populated with a file)
-- the id of the file input for the genotype file
-- the width of the overview
+- `height`: the height of the canvas
+- `mapFileDom`: the id of the file input for the map file (which may or may not have been populated with a file)
+- `genotypeFileDom`: the id of the file input for the genotype file
+- `phenotypeFileDom`: the id of the file input for the phenotype file (optional)
+- `overviewWidth`: the width of the overview
     - can be set to `null` to automatically resize the canvas to fit the available width
-    - If undefined, use the same width as the genotype view
-- the height of the overview (if undefined, use a default height)
-- the minimum width for the genotype view (auto-width mode only, optional)
-- the minimum height for the genotype view (auto-width mode only, optional)
+    - If left undefined, use the same width as the genotype view
+- `overviewHeight`: the height of the overview (if undefined, use a default height)
+- `minGenotypeAutoWidth`: the minimum width for the genotype view (auto-width mode only, optional)
+- `minOverviewAutoWidth`: the minimum height for the overview (auto-width mode only, optional)
 
 The map file and genotype file should be in their respective [Flapjack formats](http://flapjack.hutton.ac.uk/en/latest/projects_&_data_formats.html#data-sets-maps-and-genotypes)
 
@@ -205,7 +217,15 @@ loaded into the flapjack-bytes library.
   $(document).ready(function(){
     $("#submit").click(function(){
       var renderer = GenotypeRenderer();
-      renderer.renderGenotypesUrl("#canvas-holder", 800, 600, $('#mapfile').val(), $('#genofile').val(), 800, 200);
+      renderer.renderGenotypesUrl({
+        domParent: "#canvas-holder",
+        width: 800,
+        height: 600,
+        mapFileURL: $('#mapfile').val(),
+        genotypeFileURL: $('#genofile').val(),
+        overviewWidth: 800,
+        overviewHeight: 200
+      });
       return false;
     });
 });
@@ -217,20 +237,28 @@ button. The meat of the code is the following two lines:
 
 ```javascript
 var renderer = GenotypeRenderer();
-renderer.renderGenotypesUrl("#canvas-holder", 800, 600, $('#mapfile').val(),
-$('#genofile').val(), 800, 200);
+renderer.renderGenotypesUrl({
+  domParent: "#canvas-holder",
+  width: 800,
+  height: 600,
+  mapFileURL: $('#mapfile').val(),
+  genotypeFileURL: $('#genofile').val(),
+  overviewWidth: 800,
+  overviewHeight: 200
+});
 ```
 
 Where the parameters are as follows:
-- the id of the canvas to inject the flapjack-bytes canvas into
-- the width of the canvas
+- `domParent`: the id of the canvas to inject the flapjack-bytes canvas into
+- `width`: the width of the canvas
     - can be set to `null` to automatically resize the canvas to fit the available width
-- the height of the canvas
-- the value of the mapfile text input (should be a URL)
-- the value of the genotype text input (should be a URL)
-- the width of the overview
+- `height`: the height of the canvas
+- `mapFileURL`: the URL to the map file
+- `genotypeFileURL`: the URL to the genotype file
+- `phenotypeFileURL`: the URL to the phenotype file (optional)
+- `overviewWidth`: the width of the overview
     - can be set to `null` to automatically resize the canvas to fit the available width
-    - If undefined, use the same width as the genotype view
-- the height of the overview (if undefined, use a default height)
-- the minimum width for the genotype view (auto-width mode only, optional)
-- the minimum height for the genotype view (auto-width mode only, optional)
+    - If left undefined, use the same width as the genotype view
+- `overviewHeight`: the height of the overview (if undefined, use a default height)
+- `minGenotypeOverviewWidth`: the minimum width for the genotype view (auto-width mode only, optional)
+- `minGenotypeOverviewHeight`: the minimum height for the genotype view (auto-width mode only, optional)

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ renderer.renderGenotypesBrapi({
   authToken: this.authToken
   overviewWidth: 800,  // Overview width
   overviewWidth: 200,   // Overview height
+  saveSettings: false,
 });
 ```
 
@@ -104,6 +105,8 @@ The parameters are as follows:
 - `overviewHeight`: the height of the overview the library will create (if undefined, use a default height)
 - `minGenotypeAutoWidth`: the minimum width for the genotype view (auto-width mode only, optional)
 - `minOverviewAutoWidth`: the minimum width for the overview (auto-width mode only, optional)
+- `saveSettings`: Whether to save the user settings (reference lines, trait colors) (defaults to `true`)
+- `dataSetId`: Arbitrary string to identify this dataset's saved settings (if undefined, use `matrixId`)
 
 
 ### Local File
@@ -157,14 +160,9 @@ into the flapjack-bytes library.
 ```
 
 Here jQuery is just used to simplify adding the event handler to the submit
-button. The meat of the code is the following two lines:
+button. 
 
-```javascript
-var renderer = GenotypeRenderer();
-renderer.renderGenotypesFile("#canvas-holder", null, 600, "#mapfile", "#genofile", null, 200, 600, 600);
-```
-
-Where the parameters are as follows:
+The parameters are as follows:
 - `domParent`: the id of the canvas to inject the flapjack-bytes canvas into
 - `width`: the width of the canvas
     - can be set to `null` to automatically resize the canvas to fit the available width
@@ -178,6 +176,8 @@ Where the parameters are as follows:
 - `overviewHeight`: the height of the overview (if undefined, use a default height)
 - `minGenotypeAutoWidth`: the minimum width for the genotype view (auto-width mode only, optional)
 - `minOverviewAutoWidth`: the minimum height for the overview (auto-width mode only, optional)
+- `saveSettings`: Whether to save the user settings (reference lines, trait colors) (defaults to `true`)
+- `dataSetId`: Arbitrary string to identify this dataset's saved settings (if undefined, use the genotype file name)
 
 The map file and genotype file should be in their respective [Flapjack formats](http://flapjack.hutton.ac.uk/en/latest/projects_&_data_formats.html#data-sets-maps-and-genotypes)
 
@@ -244,7 +244,8 @@ renderer.renderGenotypesUrl({
   mapFileURL: $('#mapfile').val(),
   genotypeFileURL: $('#genofile').val(),
   overviewWidth: 800,
-  overviewHeight: 200
+  overviewHeight: 200,
+  dataSetId: "MyDataSet",
 });
 ```
 
@@ -262,3 +263,5 @@ Where the parameters are as follows:
 - `overviewHeight`: the height of the overview (if undefined, use a default height)
 - `minGenotypeOverviewWidth`: the minimum width for the genotype view (auto-width mode only, optional)
 - `minGenotypeOverviewHeight`: the minimum height for the genotype view (auto-width mode only, optional)
+- `saveSettings`: Whether to save the user settings (reference lines, trait colors) (defaults to `true`)
+- `dataSetId`: Arbitrary string to identify this dataset's saved settings (if undefined, use `genotypeFileURL`)

--- a/README.md
+++ b/README.md
@@ -141,12 +141,12 @@ document.addEventListener("DOMContentLoaded", function(){
     document.getElementById("submit").addEventListener("click", function(){
         var renderer = GenotypeRenderer();
         renderer.renderGenotypesFile({
-            domParent: "#canvas-holder",
+            domParent: "canvas-holder",
             width: null,
             height: 600,
-            mapFileDom: "#mapfile",
-            genotypeFileDom: "#genofile",
-            phenotypeFileDom: "#phenofile",
+            mapFileDom: "mapfile",
+            genotypeFileDom: "genofile",
+            phenotypeFileDom: "phenofile",
             overviewWidth: null,
             overviewHeight: 200,
             minGenotypeAutoWidth: 600,
@@ -214,12 +214,12 @@ document.addEventListener("DOMContentLoaded", function(){
     document.getElementById("submit").addEventListener("click", function(){
         var renderer = GenotypeRenderer();
         renderer.renderGenotypesUrl({
-            domParent: "#canvas-holder",
+            domParent: "canvas-holder",
             width: 800,
             height: 600,
-            mapFileURL: $('#mapfile').val(),
-            genotypeFileURL: $('#genofile').val(),
-            phenotypeFileURL: $('#phenotype').val(),
+            mapFileURL: document.getElementById('mapfile').value,
+            genotypeFileURL: document.getElementById('genofile').value,
+            phenotypeFileURL: document.getElementById('phenofile').value,
             overviewWidth: 800,
             overviewHeight: 200
             dataSetId: "MyDataSet",

--- a/load-from-file.html
+++ b/load-from-file.html
@@ -13,6 +13,10 @@
             <label for="genofile">Genotype file:</label>
             <input type="file" id="genofile" name="genofile">
           </div>
+          <div>
+            <label for="phenofile">Phenotype file:</label>
+            <input type="file" id="phenofile" name="phenofile">
+          </div>
           <input type="submit" action="#" id="submit" name="submit" value="Submit">
       </div>
       <div id="canvas-holder">
@@ -24,7 +28,15 @@
         $(document).ready(function(){
           $("#submit").click(function(){
             var renderer = GenotypeRenderer();
-            renderer.renderGenotypesFile("#canvas-holder", null, 600, "#mapfile", "#genofile", null, 200, 600, 600);
+            renderer.renderGenotypesFile({
+              domParent: "#canvas-holder",
+              width: null, height: 600, 
+              mapFileDom: "#mapfile",
+              genotypeFileDom: "#genofile",
+              phenotypeFileDom: "#phenofile",
+              overviewWidth: null, overviewHeight: 200,
+              minGenotypeAutoWidth: 600, minGenotypeAutoHeight: 600,
+            });
             return false;
           });
       });

--- a/load-from-file.html
+++ b/load-from-file.html
@@ -28,11 +28,11 @@
           document.getElementById("submit").addEventListener("click", function(){
             var renderer = GenotypeRenderer();
             renderer.renderGenotypesFile({
-              domParent: "#canvas-holder",
+              domParent: "canvas-holder",
               width: null, height: 600, 
-              mapFileDom: "#mapfile",
-              genotypeFileDom: "#genofile",
-              phenotypeFileDom: "#phenofile",
+              mapFileDom: "mapfile",
+              genotypeFileDom: "genofile",
+              phenotypeFileDom: "phenofile",
               overviewWidth: null, overviewHeight: 200,
               minGenotypeAutoWidth: 600, minGenotypeAutoHeight: 600,
             });

--- a/load-from-file.html
+++ b/load-from-file.html
@@ -22,11 +22,10 @@
       <div id="canvas-holder">
         <!-- Empty div that we can insert a canvas into from javascript. -->
       </div>
-      <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
       <script src="build/flapjack-bytes.js"></script>
       <script type="text/javascript">
-        $(document).ready(function(){
-          $("#submit").click(function(){
+        document.addEventListener("DOMContentLoaded", function(){
+          document.getElementById("submit").addEventListener("click", function(){
             var renderer = GenotypeRenderer();
             renderer.renderGenotypesFile({
               domParent: "#canvas-holder",

--- a/load-from-url.html
+++ b/load-from-url.html
@@ -13,6 +13,10 @@
           <label for="genofile">Genotype file:</label>
           <input type="text" id="genofile" name="genofile" value="http://bioinf.hutton.ac.uk/flapjack/sample-data/tutorials/ped-ver-tutorial.dat">
         </div>
+        <div>
+          <label for="phenofile">Phenotype file:</label>
+          <input type="text" id="phenofile" name="phenofile">
+        </div>
         <input type="submit" action="#" id="submit" name="submit" value="Submit">
       </div>
       <div id="canvas-holder">
@@ -24,7 +28,14 @@
         $(document).ready(function(){
           $("#submit").click(function(){
             var renderer = GenotypeRenderer();
-            renderer.renderGenotypesUrl("#canvas-holder", 800, 600, $('#mapfile').val(), $('#genofile').val());
+            renderer.renderGenotypesUrl({
+              domParent: "#canvas-holder",
+              width: 800,
+              height: 600,
+              mapFileURL: $('#mapfile').val(),
+              genotypeFileURL: $('#genofile').val(),
+              phenotypeFileURL: $('#phenofile').val(),
+            });
             return false;
           });
       });

--- a/load-from-url.html
+++ b/load-from-url.html
@@ -28,7 +28,7 @@
           document.getElementById("submit").addEventListener("click", function(){
             var renderer = GenotypeRenderer();
             renderer.renderGenotypesUrl({
-              domParent: "#canvas-holder",
+              domParent: "canvas-holder",
               width: 800,
               height: 600,
               mapFileURL: document.getElementById('mapfile').value,

--- a/load-from-url.html
+++ b/load-from-url.html
@@ -22,19 +22,18 @@
       <div id="canvas-holder">
         <!-- Empty div that we can insert a canvas into from javascript. -->
       </div>
-      <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
       <script src="build/flapjack-bytes.js"></script>
       <script type="text/javascript">
-        $(document).ready(function(){
-          $("#submit").click(function(){
+        document.addEventListener("DOMContentLoaded", function(){
+          document.getElementById("submit").addEventListener("click", function(){
             var renderer = GenotypeRenderer();
             renderer.renderGenotypesUrl({
               domParent: "#canvas-holder",
               width: 800,
               height: 600,
-              mapFileURL: $('#mapfile').val(),
-              genotypeFileURL: $('#genofile').val(),
-              phenotypeFileURL: $('#phenofile').val(),
+              mapFileURL: document.getElementById('mapfile').value,
+              genotypeFileURL: document.getElementById('genofile').value,
+              phenotypeFileURL: document.getElementById('phenofile').value,
             });
             return false;
           });

--- a/src/CanvasController.js
+++ b/src/CanvasController.js
@@ -112,7 +112,8 @@ export default class CanvasController {
         sortLineSelect.disabled = true;
         sortTraitSelect.disabled = false;
         
-        
+        const traitName = sortTraitSelect.options[sortTraitSelect.selectedIndex].value;
+        this.setLineSort(new TraitLineSort(traitName));
       });
 
       sortTraitSelect.addEventListener('change', (event) => {

--- a/src/CanvasController.js
+++ b/src/CanvasController.js
@@ -32,11 +32,13 @@ export default class CanvasController {
     this.dataSet = dataSet;
     const settings = this.loadDefaultSettings(this.dataSet.id);
 
-    if (settings.traitColors != null) {
+    if (settings.traitColors != null && this.dataSet.hasTraits()) {
       for (let traitName in settings.traitColors) {
         const trait = this.dataSet.getTrait(traitName);
-        for (let value in settings.traitColors[traitName])
-          trait.setHSVColor(parseFloat(value), settings.traitColors[traitName][value]);
+        if (trait !== undefined) {
+          for (let value in settings.traitColors[traitName])
+            trait.setHSVColor(parseFloat(value), settings.traitColors[traitName][value]);
+        }
       }
     }
 

--- a/src/CanvasController.js
+++ b/src/CanvasController.js
@@ -35,9 +35,8 @@ export default class CanvasController {
     if (settings.traitColors != null) {
       for (let traitName in settings.traitColors) {
         const trait = this.dataSet.getTrait(traitName);
-        for (let value in settings.traitColors[traitName]) {
+        for (let value in settings.traitColors[traitName])
           trait.setHSVColor(parseFloat(value), settings.traitColors[traitName][value]);
-        }
       }
     }
 
@@ -201,7 +200,7 @@ export default class CanvasController {
         const trait = this.dataSet.getTrait(traitName);
         let traitOptions = null;
         if (trait.type == TraitType.Numerical) {
-          traitOptions = ['min : ' + trait.minValue(), 'max : ' + trait.maxValue()];
+          traitOptions = ['min : ' + trait.minValue, 'max : ' + trait.maxValue];
         } else {
           traitOptions = trait.getValues();
         }
@@ -216,8 +215,11 @@ export default class CanvasController {
           opt.text = value;
           paletteValueSelect.add(opt);
         }
+        paletteValueSelect.selectedIndex = 0;
+        paletteValueSelect.dispatchEvent(new Event('change'));
       });
       paletteTraitSelect.value = this.dataSet.traitNames[0];
+      paletteTraitSelect.dispatchEvent(new Event('change'));
 
       paletteValueSelect.addEventListener('change', event => {
         const traitName = paletteTraitSelect.options[paletteTraitSelect.selectedIndex].value;
@@ -231,6 +233,7 @@ export default class CanvasController {
         }
         paletteValueColor.value = color;
       });
+      paletteValueSelect.dispatchEvent(new Event('change'));
 
       paletteValueColor.addEventListener('change', event => {
         const traitName = paletteTraitSelect.options[paletteTraitSelect.selectedIndex].value;
@@ -488,7 +491,7 @@ export default class CanvasController {
         settings.lineSortId = "alphabetic";
         break;
       case "trait":
-        if (this.dataSet.hasTraits() && dataSet.getTrait(sortReference) !== undefined) {
+        if (this.dataSet.hasTraits() && this.dataSet.getTrait(sortReference) !== undefined) {
           settings.lineSort = new TraitLineSort(sortReference);
           settings.lineSortId = "trait";
         }

--- a/src/CanvasController.js
+++ b/src/CanvasController.js
@@ -79,7 +79,7 @@ export default class CanvasController {
     const importingOrderRadio = document.getElementById('importingOrderSort');
     importingOrderRadio.addEventListener('change', () => {
       sortLineSelect.disabled = true;
-      sortTraitSelect.disabled = true;
+      if (sortTraitSelect !== null) sortTraitSelect.disabled = true;
 
       this.genotypeCanvas.setLineSort(new ImportingOrderLineSort());
       this.overviewCanvas.prerender(true);
@@ -88,7 +88,7 @@ export default class CanvasController {
     const alphabetOrderRadio = document.getElementById('alphabeticSort');
     alphabetOrderRadio.addEventListener('change', () => {
       sortLineSelect.disabled = true;
-      sortTraitSelect.disabled = true;
+      if (sortTraitSelect !== null) sortTraitSelect.disabled = true;
 
       this.genotypeCanvas.setLineSort(new AlphabeticLineSort());
       this.overviewCanvas.prerender(true);
@@ -97,7 +97,7 @@ export default class CanvasController {
     const similarityOrderRadio = document.getElementById('similaritySort');
     similarityOrderRadio.addEventListener('change', () => {
       sortLineSelect.disabled = false;
-      sortTraitSelect.disabled = true;
+      if (sortTraitSelect !== null) sortTraitSelect.disabled = true;
 
       const referenceName = sortLineSelect.options[sortLineSelect.selectedIndex].value;
       this.genotypeCanvas.setLineSort(new SimilarityLineSort(referenceName, [this.chromosomeIndex]));

--- a/src/CanvasController.js
+++ b/src/CanvasController.js
@@ -1,8 +1,9 @@
 import AlphabeticLineSort from './sort/AlphabeticLineSort'
 import SimilarityLineSort from './sort/SimilarityLineSort'
 import ImportingOrderLineSort from './sort/ImportingOrderLineSort'
-import NucleotideColorScheme from './color/NucleotideColorScheme';
-import SimilarityColorScheme from './color/SimilarityColorScheme';
+import TraitLineSort from './sort/TraitLineSort'
+import NucleotideColorScheme from './color/NucleotideColorScheme'
+import SimilarityColorScheme from './color/SimilarityColorScheme'
 
 
 export default class CanvasController {
@@ -58,37 +59,56 @@ export default class CanvasController {
     });
 
     // Sort
+    const sortLineSelect = document.getElementById('sortLineSelect');
+    const sortTraitSelect = document.getElementById('sortTraitSelect');
+
     const importingOrderRadio = document.getElementById('importingOrderSort');
     importingOrderRadio.addEventListener('change', () => {
-      const sortLineSelect = document.getElementById('sortLineSelect');
       sortLineSelect.disabled = true;
+      sortTraitSelect.disabled = true;
+
       this.genotypeCanvas.setLineSort(new ImportingOrderLineSort());
       this.overviewCanvas.prerender(true);
     });
 
     const alphabetOrderRadio = document.getElementById('alphabeticSort');
     alphabetOrderRadio.addEventListener('change', () => {
-      const sortLineSelect = document.getElementById('sortLineSelect');
       sortLineSelect.disabled = true;
+      sortTraitSelect.disabled = true;
+
       this.genotypeCanvas.setLineSort(new AlphabeticLineSort());
       this.overviewCanvas.prerender(true);
     });
 
     const similarityOrderRadio = document.getElementById('similaritySort');
     similarityOrderRadio.addEventListener('change', () => {
-      const sortLineSelect = document.getElementById('sortLineSelect');
       sortLineSelect.disabled = false;
+      sortTraitSelect.disabled = true;
 
       const referenceName = sortLineSelect.options[sortLineSelect.selectedIndex].value;
       this.genotypeCanvas.setLineSort(new SimilarityLineSort(referenceName, [this.chromosomeIndex]));
       this.overviewCanvas.prerender(true);
     });
 
-    const sortLineSelect = document.getElementById('sortLineSelect');
     sortLineSelect.addEventListener('change', (event) => {
       this.genotypeCanvas.setSortComparisonLine(event.target.options[event.target.selectedIndex].value);
       this.overviewCanvas.prerender(true);
     });
+
+    const traitOrderRadio = document.getElementById('traitSort');
+    traitOrderRadio.addEventListener('change', () => {
+      sortLineSelect.disabled = true;
+      sortTraitSelect.disabled = false;
+
+      const traitName = sortTraitSelect.options[sortTraitSelect.selectedIndex].value;
+      this.genotypeCanvas.setLineSort(new TraitLineSort(traitName));
+      this.overviewCanvas.prerender(true);
+    });
+
+    sortTraitSelect.addEventListener('change', (event) => {
+      this.genotypeCanvas.setSortTrait(event.target.options[event.target.selectedIndex].value);
+      this.overviewCanvas.prerender(true);
+    })
   }
 
   init(dataSet, colorScheme) {

--- a/src/CanvasController.js
+++ b/src/CanvasController.js
@@ -124,6 +124,16 @@ export default class CanvasController {
         this.genotypeCanvas.setSortTrait(event.target.options[event.target.selectedIndex].value);
         this.overviewCanvas.prerender(true);
       });
+
+      const displayTraitSelect = document.getElementById('displayTraitSelect');
+      displayTraitSelect.addEventListener('change', (event) => {
+        let displayTraits = [];
+        for (let option of displayTraitSelect){
+          if (option.selected)
+            displayTraits.push(option.value);
+        }
+        this.genotypeCanvas.setDisplayTraits(displayTraits);
+      })
     }
 
     // Set the canvas controls only once we have a valid data set and color scheme

--- a/src/CanvasController.js
+++ b/src/CanvasController.js
@@ -80,33 +80,30 @@ export default class CanvasController {
     importingOrderRadio.addEventListener('change', () => {
       sortLineSelect.disabled = true;
       if (sortTraitSelect !== null) sortTraitSelect.disabled = true;
-
-      this.genotypeCanvas.setLineSort(new ImportingOrderLineSort());
-      this.overviewCanvas.prerender(true);
+      this.setLineSort(new ImportingOrderLineSort());
     });
 
     const alphabetOrderRadio = document.getElementById('alphabeticSort');
     alphabetOrderRadio.addEventListener('change', () => {
       sortLineSelect.disabled = true;
       if (sortTraitSelect !== null) sortTraitSelect.disabled = true;
-
-      this.genotypeCanvas.setLineSort(new AlphabeticLineSort());
-      this.overviewCanvas.prerender(true);
+      this.setLineSort(new AlphabeticLineSort());
     });
 
     const similarityOrderRadio = document.getElementById('similaritySort');
     similarityOrderRadio.addEventListener('change', () => {
       sortLineSelect.disabled = false;
       if (sortTraitSelect !== null) sortTraitSelect.disabled = true;
-
+      
       const referenceName = sortLineSelect.options[sortLineSelect.selectedIndex].value;
-      this.genotypeCanvas.setLineSort(new SimilarityLineSort(referenceName, [this.chromosomeIndex]));
-      this.overviewCanvas.prerender(true);
+      this.setLineSort(new SimilarityLineSort(referenceName, [this.chromosomeIndex]));
     });
 
     sortLineSelect.addEventListener('change', (event) => {
-      this.genotypeCanvas.setSortComparisonLine(event.target.options[event.target.selectedIndex].value);
-      this.overviewCanvas.prerender(true);
+      if (!sortLineSelect.disabled){
+        const referenceName = sortLineSelect.options[sortLineSelect.selectedIndex].value;
+        this.setLineSort(new SimilarityLineSort(referenceName, [this.chromosomeIndex]));
+      }
     });
 
     if (dataSet.hasTraits()){
@@ -114,15 +111,15 @@ export default class CanvasController {
       traitOrderRadio.addEventListener('change', () => {
         sortLineSelect.disabled = true;
         sortTraitSelect.disabled = false;
-
-        const traitName = sortTraitSelect.options[sortTraitSelect.selectedIndex].value;
-        this.genotypeCanvas.setLineSort(new TraitLineSort(traitName));
-        this.overviewCanvas.prerender(true);
+        
+        
       });
 
       sortTraitSelect.addEventListener('change', (event) => {
-        this.genotypeCanvas.setSortTrait(event.target.options[event.target.selectedIndex].value);
-        this.overviewCanvas.prerender(true);
+        if (!sortTraitSelect.disabled){
+          const traitName = sortTraitSelect.options[sortTraitSelect.selectedIndex].value;
+          this.setLineSort(new TraitLineSort(traitName));
+        }
       });
 
       const displayTraitSelect = document.getElementById('displayTraitSelect');
@@ -201,6 +198,17 @@ export default class CanvasController {
     });
   }
 
+  setLineSort(lineSort){
+    this.disableCanvas();
+
+    // Yield control to the browser to make a render (to show the grey overlay)
+    setTimeout(() => {
+      this.genotypeCanvas.setLineSort(lineSort);
+      this.overviewCanvas.prerender(true);
+      this.enableCanvas();
+    }, 4);
+  }
+
   updateAutoWidth() {
     const computedStyles = window.getComputedStyle(this.canvasContainer);
     const autoWidth = this.canvasContainer.clientWidth - parseInt(computedStyles.paddingLeft) - parseInt(computedStyles.paddingRight);
@@ -225,6 +233,16 @@ export default class CanvasController {
     this.genotypeCanvas.setChromosome(chromosomeIndex);
     this.overviewCanvas.setChromosome(chromosomeIndex);
     this.overviewCanvas.moveToPosition(0, 0, this.genotypeCanvas.visibilityWindow());
+  }
+
+  disableCanvas() {
+    this.genotypeCanvas.disable();
+    this.overviewCanvas.disable();
+  }
+
+  enableCanvas(self) {
+    this.genotypeCanvas.enable();
+    this.overviewCanvas.enable();
   }
 
   getGenotypeMouseLocation(clientX, clientY) {

--- a/src/CanvasController.js
+++ b/src/CanvasController.js
@@ -189,6 +189,7 @@ export default class CanvasController {
       const paletteTraitSelect = document.getElementById('paletteTrait');
       const paletteValueSelect = document.getElementById('paletteValue');
       const paletteValueColor = document.getElementById('paletteColor');
+      const paletteResetButton = document.getElementById('paletteReset');
 
       this.dataSet.traitNames.forEach(traitName => {
         const opt = document.createElement('option');
@@ -253,6 +254,15 @@ export default class CanvasController {
         this.genotypeCanvas.prerender(true);
         this.saveColors();
       });
+
+      paletteResetButton.addEventListener('click', event => {
+        const traitName = paletteTraitSelect.options[paletteTraitSelect.selectedIndex].value;
+        const trait = this.dataSet.getTrait(traitName);
+        trait.resetColors();
+        this.genotypeCanvas.prerender(true);
+        paletteValueSelect.dispatchEvent(new Event('change'));
+        this.saveColors();
+      })
     }
 
     // Set the canvas controls only once we have a valid data set and color scheme

--- a/src/CanvasController.js
+++ b/src/CanvasController.js
@@ -57,6 +57,20 @@ export default class CanvasController {
       this.genotypeCanvas.setColorComparisonLine(event.target.options[event.target.selectedIndex].value);
       this.overviewCanvas.prerender(true);
     });
+  }
+
+  init(dataSet, colorScheme) {
+    // Initialize the components
+    this.genotypeCanvas.init(dataSet, colorScheme);
+    this.genotypeCanvas.prerender(true);
+    this.overviewCanvas.init(dataSet, colorScheme, this.genotypeCanvas.visibilityWindow());
+    this.overviewCanvas.prerender(true);
+
+    this.updateAutoWidth();
+
+    window.addEventListener("resize", event => {
+      this.updateAutoWidth();
+    });
 
     // Sort
     const sortLineSelect = document.getElementById('sortLineSelect');
@@ -95,34 +109,22 @@ export default class CanvasController {
       this.overviewCanvas.prerender(true);
     });
 
-    const traitOrderRadio = document.getElementById('traitSort');
-    traitOrderRadio.addEventListener('change', () => {
-      sortLineSelect.disabled = true;
-      sortTraitSelect.disabled = false;
+    if (dataSet.hasTraits()){
+      const traitOrderRadio = document.getElementById('traitSort');
+      traitOrderRadio.addEventListener('change', () => {
+        sortLineSelect.disabled = true;
+        sortTraitSelect.disabled = false;
 
-      const traitName = sortTraitSelect.options[sortTraitSelect.selectedIndex].value;
-      this.genotypeCanvas.setLineSort(new TraitLineSort(traitName));
-      this.overviewCanvas.prerender(true);
-    });
+        const traitName = sortTraitSelect.options[sortTraitSelect.selectedIndex].value;
+        this.genotypeCanvas.setLineSort(new TraitLineSort(traitName));
+        this.overviewCanvas.prerender(true);
+      });
 
-    sortTraitSelect.addEventListener('change', (event) => {
-      this.genotypeCanvas.setSortTrait(event.target.options[event.target.selectedIndex].value);
-      this.overviewCanvas.prerender(true);
-    })
-  }
-
-  init(dataSet, colorScheme) {
-    // Initialize the components
-    this.genotypeCanvas.init(dataSet, colorScheme);
-    this.genotypeCanvas.prerender(true);
-    this.overviewCanvas.init(dataSet, colorScheme, this.genotypeCanvas.visibilityWindow());
-    this.overviewCanvas.prerender(true);
-
-    this.updateAutoWidth();
-
-    window.addEventListener("resize", event => {
-      this.updateAutoWidth();
-    });
+      sortTraitSelect.addEventListener('change', (event) => {
+        this.genotypeCanvas.setSortTrait(event.target.options[event.target.selectedIndex].value);
+        this.overviewCanvas.prerender(true);
+      });
+    }
 
     // Set the canvas controls only once we have a valid data set and color scheme
     // If they are set in the constructor, moving the mouse above the canvas before

--- a/src/DataSet.js
+++ b/src/DataSet.js
@@ -1,14 +1,31 @@
 import {buildSimilarityLookupTable} from './Similarity'
 
 export default class DataSet {
-  constructor(genomeMap, germplasmList, stateTable) {
+  constructor(genomeMap, germplasmList, stateTable, traits, phenotypes) {
     this.genomeMap = genomeMap;
     this.germplasmList = germplasmList;
+    this.stateTable = stateTable;
+    this.traits = traits;
+
     // Keep the importing order to allow getting back to it later on
     this.importingOrder = germplasmList.map(germplasm => germplasm.name);
-    this.stateTable = stateTable;
+
     // Pre-compute the similarity matrix
     this.similarityLookupTable = buildSimilarityLookupTable(this.stateTable);
+
+    
+    if (this.traits !== undefined){
+      // Pre-order the traits
+      this.traitNames = Array.from(this.traits.keys());
+      this.traitNames.sort();
+
+      // Set the germplasms' traits
+      this.germplasmList.forEach(germplasm => {
+        germplasm.phenotype = phenotypes.get(germplasm.name);
+      });
+    } else {
+      this.traitNames = undefined;
+    }
   }
 
   germplasmFor(germplasmStart, germplasmEnd) {
@@ -49,5 +66,13 @@ export default class DataSet {
 
   lineCount() {
     return this.germplasmList.length;
+  }
+
+  hasTraits(){
+    return this.traits !== undefined;
+  }
+
+  getTrait(traitName) {
+    return this.traits.get(traitName);
   }
 }

--- a/src/DataSet.js
+++ b/src/DataSet.js
@@ -1,7 +1,8 @@
 import {buildSimilarityLookupTable} from './Similarity'
 
 export default class DataSet {
-  constructor(genomeMap, germplasmList, stateTable, traits, phenotypes) {
+  constructor(dataSetId, genomeMap, germplasmList, stateTable, traits, phenotypes) {
+    this.id = dataSetId;
     this.genomeMap = genomeMap;
     this.germplasmList = germplasmList;
     this.stateTable = stateTable;
@@ -68,11 +69,13 @@ export default class DataSet {
     return this.germplasmList.length;
   }
 
-  hasTraits(){
+  hasTraits() {
     return this.traits !== undefined;
   }
 
   getTrait(traitName) {
+    if (!this.hasTraits())
+      return undefined;
     return this.traits.get(traitName);
   }
 }

--- a/src/GenotypeCanvas.js
+++ b/src/GenotypeCanvas.js
@@ -67,7 +67,7 @@ export default class GenotypeCanvas {
   }
 
   maxCanvasHeight() {
-    return Math.max(this.dataSet.lineCount() * this.boxSize, this.alleleCanvasHeight());
+    return Math.max(this.alleleUsedHeight(), this.alleleCanvasHeight());
   }
 
   alleleCanvasWidth() {
@@ -76,6 +76,10 @@ export default class GenotypeCanvas {
 
   alleleCanvasHeight() {
     return this.canvas.height - this.mapCanvasHeight - this.scrollbarHeight;
+  }
+
+  alleleUsedHeight() {
+    return this.dataSet.lineCount() * this.boxSize;
   }
 
   maxDataHeight() {
@@ -204,7 +208,7 @@ export default class GenotypeCanvas {
       this.drawingContext.translate(this.traitCanvasWidth, this.mapCanvasHeight);
       // Prevent line name under scrollbar being highlighted
       const region = new Path2D();
-      const clipHeight = this.canScrollX() ? this.alleleCanvasHeight() : this.canvas.height;
+      const clipHeight = this.canScrollX() ? this.alleleCanvasHeight() : this.alleleUsedHeight();
       region.rect(0, 0, this.nameCanvasWidth, clipHeight);
       this.drawingContext.clip(region);
 
@@ -226,7 +230,7 @@ export default class GenotypeCanvas {
       
       // Prevent line name under scrollbar being highlighted
       const region = new Path2D();
-      const clipHeight = this.canScrollX() ? this.alleleCanvasHeight() : this.canvas.height;
+      const clipHeight = this.canScrollX() ? this.alleleCanvasHeight() : this.alleleUsedHeight();
       region.rect(0, 0, this.traitValuesCanvasWidth, clipHeight);
       this.drawingContext.clip(region);
 
@@ -266,7 +270,7 @@ export default class GenotypeCanvas {
       this.drawingContext.translate(this.traitCanvasWidth + this.nameCanvasWidth + this.traitValuesCanvasWidth, this.mapCanvasHeight);
       // Prevent line name under scrollbar being highlighted
       const region = new Path2D();
-      const clipHeight = this.canScrollX() ? this.alleleCanvasHeight() : this.canvas.height;
+      const clipHeight = this.canScrollX() ? this.alleleCanvasHeight() : this.alleleUsedHeight();
       region.rect(0, 0, this.scoreCanvasWidth, clipHeight);
       this.drawingContext.clip(region);
 
@@ -443,7 +447,7 @@ export default class GenotypeCanvas {
     const region = new Path2D();
     // We need to take account of the scrollbar potentially disappearing when
     // zoomed out
-    const clipHeight = this.canScrollX() ? this.alleleCanvasHeight() : this.canvas.height;
+    const clipHeight = this.canScrollX() ? this.alleleCanvasHeight() : this.alleleUsedHeight();
     region.rect(0, this.mapCanvasHeight, this.traitCanvasWidth, clipHeight);
     this.backContext.clip(region);
 
@@ -481,7 +485,7 @@ export default class GenotypeCanvas {
     const region = new Path2D();
     // We need to take account of the scrollbar potentially disappearing when
     // zoomed out
-    const clipHeight = this.canScrollX() ? this.alleleCanvasHeight() : this.canvas.height;
+    const clipHeight = this.canScrollX() ? this.alleleCanvasHeight() : this.alleleUsedHeight();
     region.rect(this.traitCanvasWidth, this.mapCanvasHeight, this.nameCanvasWidth, clipHeight);
     this.backContext.clip(region);
 
@@ -509,7 +513,7 @@ export default class GenotypeCanvas {
     const region = new Path2D();
     // We need to take account of the scrollbar potentially disappearing when
     // zoomed out
-    const clipHeight = this.canScrollX() ? this.alleleCanvasHeight() : this.canvas.height;
+    const clipHeight = this.canScrollX() ? this.alleleCanvasHeight() : this.alleleUsedHeight();
     region.rect(this.traitCanvasWidth + this.nameCanvasWidth, this.mapCanvasHeight, this.traitValuesCanvasWidth, clipHeight);
     this.backContext.clip(region);
 
@@ -560,7 +564,7 @@ export default class GenotypeCanvas {
     const region = new Path2D();
     // We need to take account of the scrollbar potentially disappearing when
     //zoomed out
-    const clipHeight = this.canScrollX() ? this.alleleCanvasHeight() : this.canvas.height;
+    const clipHeight = this.canScrollX() ? this.alleleCanvasHeight() : this.alleleUsedHeight();
     region.rect(this.traitCanvasWidth + this.nameCanvasWidth + this.traitValuesCanvasWidth, this.mapCanvasHeight, this.scoreCanvasWidth, clipHeight);
     this.backContext.clip(region);
 

--- a/src/GenotypeCanvas.js
+++ b/src/GenotypeCanvas.js
@@ -554,10 +554,8 @@ export default class GenotypeCanvas {
           const traitValue = trait.getValue(phenotype);
 
           if (traitValue !== undefined) {
-            const scaleValue = trait.scaleValue(phenotype);
-            const hue = 120 * scaleValue;
-            const rgb = this.hsv2rgb(hue, 0.53, 1);
-            this.backContext.fillStyle = "rgb(" + Math.floor(rgb[0] * 255) + "," + Math.floor(rgb[1] * 255) + "," + Math.floor(rgb[2] * 255) + ")";
+            this.backContext.fillStyle = trait.getColor(phenotype);
+            //this.backContext.fillStyle = "rgb(" + Math.floor(rgb[0] * 255) + "," + Math.floor(rgb[1] * 255) + "," + Math.floor(rgb[2] * 255) + ")";
             this.backContext.fillRect(xPos, yPos, this.traitValueColumnWidths[traitIndex], this.boxSize);
             
             this.backContext.fillStyle = "#333";
@@ -1088,11 +1086,6 @@ export default class GenotypeCanvas {
     tmpContext.drawImage(this.canvas, 0, 0);
 
     return tmpCanvas.toDataURL(type, encoderOptions);
-  }
-
-  hsv2rgb(h, s, v) {
-    let f = (n, k = (n + h/60) % 6) => v - v*s*Math.max(Math.min(k, 4-k, 1), 0);     
-    return [f(5), f(3), f(1)];       
   }
 
   nextColumnBackground() {

--- a/src/GenotypeCanvas.js
+++ b/src/GenotypeCanvas.js
@@ -117,6 +117,7 @@ export default class GenotypeCanvas {
     this.renderCrosshair(markerStart, xPos, germplasmStart, yPos);
     this.highlightMarker(dataWidth, markerStart, markerEnd, xPos);
     this.highlightLineName(germplasmStart, yPos);
+    if (this.dataSet.hasTraits()) this.highlightLineTraitValues(germplasmStart, yPos);
     if (this.lineSort.hasScore) this.highlightLineScore(germplasmStart, yPos);
     this.renderMouseOverText();
   }
@@ -210,6 +211,48 @@ export default class GenotypeCanvas {
 
       const y = yPos + (this.boxSize - (this.fontSize / 2));
       this.drawingContext.fillText(name, 0, y);
+      this.drawingContext.restore();
+    }
+  }
+
+  highlightLineTraitValues(germplasmStart, yPos) {
+    if (this.lineUnderMouse !== undefined){
+      this.drawingContext.save();
+      this.drawingContext.translate(this.traitCanvasWidth + this.nameCanvasWidth, this.mapCanvasHeight);
+      
+      // Prevent line name under scrollbar being highlighted
+      const region = new Path2D();
+      const clipHeight = this.canScrollX() ? this.alleleCanvasHeight() : this.canvas.height;
+      region.rect(0, 0, this.traitValuesCanvasWidth, clipHeight);
+      this.drawingContext.clip(region);
+
+      this.drawingContext.fillStyle = '#F00';
+      this.drawingContext.font = this.font;
+
+      const germplasm = this.dataSet.germplasmList[this.lineIndexUnderMouse];
+
+      if (germplasm.phenotype !== undefined){
+        let xPos = 0;
+        this.dataSet.traitNames.forEach((traitName, traitIndex) => {
+          const trait = this.dataSet.getTrait(traitName);
+          const traitValue = trait.getValue(germplasm.getPhenotype(traitName));
+
+          if (traitValue !== undefined){
+            this.drawingContext.save();
+            const column = new Path2D();
+            column.rect(xPos, 0, this.traitValueColumnWidths[traitIndex], clipHeight);
+            this.drawingContext.clip(column);
+
+            const y = yPos + (this.boxSize - (this.fontSize / 2));
+            console.log(xPos + this.scorePadding, y);
+            this.drawingContext.fillText(traitValue.toString(), xPos + this.scorePadding, y);
+            this.drawingContext.restore();
+          };
+
+          xPos += this.traitValueColumnWidths[traitIndex];
+        });
+      }
+
       this.drawingContext.restore();
     }
   }

--- a/src/GenotypeCanvas.js
+++ b/src/GenotypeCanvas.js
@@ -60,6 +60,8 @@ export default class GenotypeCanvas {
 
     this.mouseOverText = undefined;
     this.mouseOverPosition = undefined;
+
+    this.enabled = true;
   }
 
   maxCanvasWidth() {
@@ -103,6 +105,7 @@ export default class GenotypeCanvas {
   }
 
   prerender(redraw) {
+    this.drawingContext.save();
     this.drawingContext.clearRect(0, 0, this.canvas.width, this.canvas.height);
 
     const dataWidth = Math.ceil((this.alleleCanvasWidth()) / this.boxSize);
@@ -128,6 +131,12 @@ export default class GenotypeCanvas {
     this.highlightLineTraitValues(germplasmStart, yPos);
     this.highlightLineScore(germplasmStart, yPos);
     this.renderMouseOverText();
+
+    if (!this.enabled){
+      this.drawingContext.fillStyle = 'rgba(150, 150, 150, 0.4)';
+      this.drawingContext.fillRect(0, 0, this.canvas.width, this.canvas.height);
+    }
+    this.drawingContext.restore();
   }
 
   calcMapMarkerPos(marker, firstMarkerPos, mapScaleFactor, drawStart) {
@@ -653,6 +662,8 @@ export default class GenotypeCanvas {
   }
 
   moveX(diffX) {
+    if (!this.enabled) return;
+
     const xScrollMax = this.maxCanvasWidth() - this.alleleCanvasWidth();
 
     if (this.canScrollX()) {
@@ -673,6 +684,8 @@ export default class GenotypeCanvas {
   }
 
   moveY(diffY) {
+    if (!this.enabled) return;
+
     const yScrollMax = this.maxCanvasHeight() - this.alleleCanvasHeight();
 
     if (this.canScrollY()) {
@@ -693,6 +706,8 @@ export default class GenotypeCanvas {
   }
 
   dragVerticalScrollbar(y) {
+    if (!this.enabled) return;
+
     if (this.canScrollY()) {
       const yScrollMax = this.maxCanvasHeight() - this.alleleCanvasHeight();
 
@@ -715,6 +730,8 @@ export default class GenotypeCanvas {
   }
 
   dragHorizontalScrollbar(x) {
+    if (!this.enabled) return;
+
     if (this.canScrollX()) {
       const xScrollMax = this.maxCanvasWidth() - this.alleleCanvasWidth();
 
@@ -751,6 +768,8 @@ export default class GenotypeCanvas {
   }
 
   mouseOver(x, y) {
+    if (!this.enabled) return;
+
     const mouseXPos = x - this.alleleCanvasXOffset;
     const mouseYPos = y - this.mapCanvasHeight;
 
@@ -1069,6 +1088,16 @@ export default class GenotypeCanvas {
 
   resetColumnBackground() {
     this.currentColumnBackground = 1;
+  }
+
+  disable() {
+    this.enabled = false;
+    this.prerender(false);
+  }
+
+  enable() {
+    this.enabled = true;
+    this.prerender(false);
   }
 
 //   rainbowColor(numOfSteps, step) {

--- a/src/GenotypeCanvas.js
+++ b/src/GenotypeCanvas.js
@@ -940,8 +940,17 @@ export default class GenotypeCanvas {
   }
 
   setSortComparisonLine(comparedName) {
-    this.lineSort.setComparisonLine(comparedName);
-    this.sortLines();
+    if (this.lineSort.setComparisonLine !== undefined){
+      this.lineSort.setComparisonLine(comparedName);
+      this.sortLines();
+    }
+  }
+
+  setSortTrait(comparedTrait) {
+    if (this.lineSort.setTrait !== undefined){
+      this.lineSort.setTrait(comparedTrait);
+      this.sortLines();
+    }
   }
 
   setChromosome(chromosomeIndex) {
@@ -950,7 +959,9 @@ export default class GenotypeCanvas {
     // Reset the position
     this.moveToPosition(0, 0);
 
-    this.lineSort.setChromosomes([chromosomeIndex]);
+    if (this.lineSort.setChromosomes !== undefined){
+      this.lineSort.setChromosomes([chromosomeIndex]);
+    }
     this.sortLines();  // This redraws too
   }
 

--- a/src/Germplasm.js
+++ b/src/Germplasm.js
@@ -1,6 +1,12 @@
 export default class Germplasm {
-  constructor(name, genotypeData) {
+  constructor(name, genotypeData, phenotype) {
     this.name = name;
     this.genotypeData = genotypeData;
+    this.phenotype = phenotype;
+  }
+
+  getPhenotype(traitName) {
+    if (this.phenotype !== undefined)
+      return this.phenotype.get(traitName);
   }
 }

--- a/src/OverviewCanvas.js
+++ b/src/OverviewCanvas.js
@@ -22,6 +22,8 @@ export default class OverviewCanvas {
     this.dataSet = undefined;
     this.colorScheme = undefined;
     this.selectedChromosome = 0;
+
+    this.enabled = true;
   }
 
   init (dataSet, colorScheme, visibilityWindow){
@@ -32,12 +34,21 @@ export default class OverviewCanvas {
   }
 
   prerender (redraw){
+    this.drawingContext.save();
+
     if (redraw){
       this.renderImage(this.backContext, this.width, this.height, false);
     }
 
     this.drawingContext.drawImage(this.backBuffer, 0, 0);
     this.renderWindow();
+
+    if (!this.enabled){
+      this.drawingContext.fillStyle = 'rgba(150, 150, 150, 0.4)';
+      this.drawingContext.fillRect(0, 0, this.canvas.width, this.canvas.height);
+    }
+
+    this.drawingContext.restore();
   }
 
   // Draw the genotype canvas' visibility window
@@ -104,6 +115,8 @@ export default class OverviewCanvas {
 
   // Set the center of the visibility window to (mouseX, mouseY)
   mouseDrag (mouseX, mouseY, visibilityWindow){
+    if (!this.enabled) return;
+
     const scale = this.renderingScale(this.width, this.height);
     const centerMarker = mouseX * scale.markersPerPixel;
     const centerGermplasm = mouseY * scale.germplasmsPerPixel;
@@ -120,6 +133,8 @@ export default class OverviewCanvas {
 
   // Set the visibility window, given its data coordinates
   moveToPosition (marker, germplasm, visibilityWindow){
+    if (!this.enabled) return;
+
     this.windowRect = this.windowFromPosition(marker, germplasm, visibilityWindow);
     this.prerender(false);
 
@@ -145,6 +160,16 @@ export default class OverviewCanvas {
 
   exportName (){
     return `overview-${this.dataSet.genomeMap.chromosomes[this.selectedChromosome].name}`;
+  }
+
+  disable (){
+    this.enabled = false;
+    this.prerender(false);
+  }
+
+  enable (){
+    this.enabled = true;
+    this.prerender(false);
   }
 
   // Export the overview to an image

--- a/src/OverviewCanvas.js
+++ b/src/OverviewCanvas.js
@@ -26,9 +26,9 @@ export default class OverviewCanvas {
     this.enabled = true;
   }
 
-  init (dataSet, colorScheme, visibilityWindow){
+  init (dataSet, settings, visibilityWindow){
     this.dataSet = dataSet;
-    this.colorScheme = colorScheme;
+    this.colorScheme = settings.colorScheme;
     this.moveToPosition(0, 0, visibilityWindow);
     this.prerender(true);
   }

--- a/src/PhenotypeImporter.js
+++ b/src/PhenotypeImporter.js
@@ -1,0 +1,121 @@
+import {Trait, TraitType} from "./Trait"
+
+
+export default class PhenotypeImporter {
+  constructor (){
+    this.traitNames = [];
+    this.experiments = [];
+    this.values = [];
+    this.traits = new Map();
+    this.valueToIndex = new Map();
+    this.phenotypes = new Map();
+  }
+
+  loadData(lines){
+    let parsedHeaderLines = 0;
+
+    for (let index = 0; index < lines.length; index += 1){
+      const line = lines[index];
+      if (line.startsWith('#') || (!line || line.length === 0))
+        continue;
+
+      if (line.startsWith("\t")){
+        if (parsedHeaderLines == 0){  // Traits
+          this.traitNames = line.split("\t").slice(1);
+        } else if (parsedHeaderLines == 1){  // Experiments
+          this.experiments = line.split("\t").slice(1);
+        }
+      } else {
+        this.values.push(line.split("\t"));
+      }
+    }
+  }
+
+  buildTraits() {
+    for (let traitIndex = 0; traitIndex < this.traitNames.length; traitIndex += 1){
+      const traitName = this.traitNames[traitIndex];
+      const experiment = this.experiments[traitIndex];  // May be undefined
+      const values = this.values.map(germplasmValues => germplasmValues[traitIndex + 1]);
+      let traitType;
+
+      if (traitName.includes("_#CAT")){
+        traitType = TraitType.Category;
+        traitName = traitName.replace("_#CAT", "");
+      } else if (traitName.includes("_#NUM")){
+        traitType = TraitType.Numerical;
+        traitName = traitName.replace("_#NUM", "");
+      } else {
+        const numValues = values.map(value => parseFloat(value));
+        if (numValues.some(value => isNaN(value))){  // At least one value is not numerical
+          traitType = TraitType.Category;
+        } else {
+          traitType = TraitType.Numerical;
+        }
+      }
+
+      traitName = traitName.trim();
+      const trait = new Trait(traitName, traitType, experiment);
+      
+      if (traitType == TraitType.Category){
+        let valueToIndex = new Map();
+        let valueIndex = 0;
+        let maxLength = 0;
+        values.sort();
+        for (let value of values){
+          if (!valueToIndex.has(value)){
+            valueToIndex.set(value, valueIndex);
+            valueIndex += 1;
+            if (value.length > maxLength) trait.longestValue = value;
+          }
+        }
+        this.valueToIndex.set(traitName, valueToIndex);
+        trait.setValues(Array.from(valueToIndex.keys()));
+        trait.setScale(0, valueIndex - 1);
+      } else {
+        const numValues = values.map(value => parseFloat(value));
+        let minValue = numValues[0], maxValue = numValues[0];
+        let maxLength = 0;
+        numValues.slice(1).forEach(value => {
+          if (value < minValue) minValue = value;
+          if (value > maxValue) maxValue = value;
+          if (value.toString().length > maxLength) trait.longestValue = value.toString();
+        })
+        trait.setScale(minValue, maxValue);
+      }
+
+      this.traits.set(traitName, trait);
+      this.traitNames[traitIndex] = traitName;
+    }
+  }
+
+  buildPhenotypes() {
+    for (let index = 0; index < this.values.length; index += 1){
+      const values = this.values[index];
+      const germplasmName = values[0];
+      const traitValues = values.slice(1);
+      const phenotype = new Map();
+      for (let traitIndex = 0; traitIndex < traitValues.length; traitIndex += 1){
+        const trait = this.traits.get(this.traitNames[traitIndex]);
+        
+        let value;
+        if (trait.type == TraitType.Category){
+          value = this.valueToIndex.get(trait.name).get(traitValues[traitIndex]);
+        } else if (trait.type == TraitType.Numerical){
+          value = parseFloat(traitValues[traitIndex].trim());
+        }
+
+        phenotype.set(trait.name, value);
+      }
+      this.phenotypes.set(germplasmName.trim(), phenotype);
+    }
+    return this.phenotypes;
+  }
+
+  parseFile(fileContents){
+    const lines = fileContents.split(/\r?\n/);
+    this.loadData(lines);
+    this.buildTraits();
+    return this.buildPhenotypes();
+  }
+};
+

--- a/src/Trait.js
+++ b/src/Trait.js
@@ -1,0 +1,35 @@
+export const TraitType = {
+  Category: 0,
+  Numerical: 1,
+};
+
+export class Trait {
+  constructor (name, type, experiment){
+    this.name = name;
+    this.type = type;
+    this.experiment = experiment;
+    this.values = undefined;
+    this.longestValue = undefined;
+  }
+
+  setValues (values){
+    this.values = values;
+  }
+
+  setScale (min, max){
+    this.minValue = min;
+    this.maxValue = max;
+  }
+
+  scaleValue (value){
+    return (value - this.minValue) / (this.maxValue - this.minValue);
+  }
+
+  getValue (value) {
+    if (this.type == TraitType.Category) {
+      return this.values[value];
+    } else {
+      return value;
+    }
+  }
+};

--- a/src/Trait.js
+++ b/src/Trait.js
@@ -36,8 +36,8 @@ export class Trait {
     if (this.type == TraitType.Category) {
       this.setCategoryColors();
     } else if (this.type == TraitType.Numerical) {
-      this.color.set(this.minValue, DEFAULT_GRADIENT_MIN);
-      this.color.set(this.maxValue, DEFAULT_GRADIENT_MAX);
+      this.colors.set(this.minValue, DEFAULT_GRADIENT_MIN);
+      this.colors.set(this.maxValue, DEFAULT_GRADIENT_MAX);
     }
   }
 

--- a/src/Trait.js
+++ b/src/Trait.js
@@ -3,25 +3,54 @@ export const TraitType = {
   Numerical: 1,
 };
 
+// Colors are in HSV (hue, saturation, value)
+const DEFAULT_HUE_MIN = 0;
+const DEFAULT_HUE_MAX = 120;
+const DEFAULT_SATURATION = 0.53;
+const DEFAULT_VALUE = 1;
+const DEFAULT_GRADIENT_MIN = [DEFAULT_HUE_MIN, DEFAULT_SATURATION, DEFAULT_VALUE];
+const DEFAULT_GRADIENT_MAX = [DEFAULT_HUE_MAX, DEFAULT_SATURATION, DEFAULT_VALUE];
+
+
 export class Trait {
-  constructor (name, type, experiment){
+  constructor (name, type, experiment) {
     this.name = name;
     this.type = type;
     this.experiment = experiment;
     this.values = undefined;
+    this.colors = new Map();
     this.longestValue = undefined;
+    this.minValue = undefined;
+    this.maxValue = undefined;
   }
 
-  setValues (values){
+  setValues (values) {
     this.values = values;
   }
 
-  setScale (min, max){
+  setScale (min, max) {
     this.minValue = min;
     this.maxValue = max;
+
+    if (this.type == TraitType.Category) {
+      this.setCategoryColors();
+    } else if (this.type == TraitType.Numerical) {
+      this.color.set(this.minValue, DEFAULT_GRADIENT_MIN);
+      this.color.set(this.maxValue, DEFAULT_GRADIENT_MAX);
+    }
   }
 
-  scaleValue (value){
+  setCategoryColors() {
+    const sortedValues = this.values.slice();
+    for (let valueIndex = 0; valueIndex < this.values.length; valueIndex++) {
+      const value = this.values[valueIndex];
+      const index = sortedValues.indexOf(value);
+      const hue = (DEFAULT_HUE_MAX - DEFAULT_HUE_MIN) * index/(sortedValues.length-1) + DEFAULT_HUE_MIN;
+      this.colors.set(valueIndex, [hue, DEFAULT_SATURATION, DEFAULT_VALUE]);
+    }
+  }
+
+  scaleValue (value) {
     return (value - this.minValue) / (this.maxValue - this.minValue);
   }
 
@@ -31,5 +60,55 @@ export class Trait {
     } else {
       return value;
     }
+  }
+
+  getValues() {
+    if (this.type == TraitType.Category)
+      return this.values.slice();
+    else
+      return [this.minValue, this.maxValue]
+  }
+
+  getMinColor() {
+    return this.getColor(this.minValue);
+  }
+
+  getMaxColor() {
+    return this.getColor(this.maxValue);
+  }
+
+  getColor(value) {
+    const hsv = this.colors.get(value);
+    const rgb = this.hsv2rgb(hsv[0], hsv[1], hsv[2]);
+    const hexa = '#' + ((1 << 24) | (Math.floor(rgb[0] * 255) << 16) | (Math.floor(rgb[1] * 255) << 8) | Math.floor(rgb[2] * 255)).toString(16).slice(1);
+    return hexa;
+  }
+
+  setMinColor(color) {
+    this.setColor(this.minValue, color);
+  }
+
+  setMaxColor(color) {
+    this.setColor(this.maxValue, color);
+  }
+
+  setColor(value, color) {
+    const rgb = [parseInt(color.slice(1, 3), 16) / 255, parseInt(color.slice(3, 5), 16) / 255, parseInt(color.slice(5, 7), 16) / 255];
+    const hsv = this.rgb2hsv(rgb[0], rgb[1], rgb[2]);
+    this.colors.set(value, hsv);
+  }
+
+  // From https://stackoverflow.com/a/54024653
+  hsv2rgb(h, s, v) {
+    let f = (n, k = (n + h/60) % 6) => v - v*s*Math.max(Math.min(k, 4-k, 1), 0);
+    return [f(5), f(3), f(1)];       
+  }
+
+  // From https://stackoverflow.com/a/54070620
+  rgb2hsv(r, g, b) {
+    let v = Math.max(r, g, b)
+    let c = v-Math.min(r, g, b);
+    let h = c && ((v == r) ? (g-b)/c : ((v == g) ? 2 + (b-r)/c : 4 + (r-g)/c)); 
+    return [60*(h<0 ? h+6 : h), v&&c / v, v];
   }
 };

--- a/src/Trait.js
+++ b/src/Trait.js
@@ -32,7 +32,11 @@ export class Trait {
   setScale (min, max) {
     this.minValue = min;
     this.maxValue = max;
+    this.resetColors();
+  }
 
+  resetColors() {
+    this.customColors.clear();
     if (this.type == TraitType.Category) {
       this.setCategoryColors();
     } else if (this.type == TraitType.Numerical) {

--- a/src/flapjack-bytes.js
+++ b/src/flapjack-bytes.js
@@ -179,9 +179,11 @@ export default function GenotypeRenderer() {
     const colorFieldSet = createColorSchemeFieldset(config);
     const sortFieldSet = createSortFieldSet(config);
     const exportFieldSet = createExportFieldSet(config);
+    const displayFieldSet = createDisplayFieldSet(config);
 
     formRow.appendChild(colorFieldSet);
     formRow.appendChild(sortFieldSet);
+    if (displayFieldSet !== undefined) formRow.appendChild(displayFieldSet);
     formRow.appendChild(exportFieldSet);
     form.appendChild(formRow);
     controlDiv.appendChild(form);
@@ -370,6 +372,39 @@ export default function GenotypeRenderer() {
     return formCol;
   }
 
+  function createDisplayFieldSet(config){
+    if ((config.phenotypeFileDom !== undefined && document.getElementById(config.phenotypeFileDom.slice(1)).files[0] !== undefined) || config.phenotypeFileURL !== undefined){
+      const formCol = document.createElement('div');
+      formCol.classList.add('col');
+
+      const formGroup = document.createElement('div');
+      formGroup.classList.add('form-group');
+
+      const fieldSet = document.createElement('fieldset');
+      fieldSet.classList.add('bytes-fieldset');
+
+      const legend = document.createElement('legend');
+      const legendText = document.createTextNode('Display option');
+      legend.appendChild(legendText);
+
+      const traitSelectLegend = document.createElement('div');
+      const traitSelectLegendText = document.createTextNode('Traits to display');
+      traitSelectLegend.appendChild(traitSelectLegendText);
+
+      const traitSelect = document.createElement('select');
+      traitSelect.id = 'displayTraitSelect';
+      traitSelect.multiple = true;
+      traitSelect.size = 5;
+
+      fieldSet.appendChild(legend);
+      fieldSet.appendChild(traitSelectLegend);
+      fieldSet.appendChild(traitSelect);
+      formGroup.appendChild(fieldSet);
+      formCol.appendChild(formGroup);
+      return formCol;
+    }
+  }
+
   function setProgressBarLabel(newLabel) {
     progressBarLabel.data = newLabel;
   }
@@ -433,7 +468,7 @@ export default function GenotypeRenderer() {
     domParent,
     width,
     height,
-    server,
+    baseURL,
     matrixId,
     mapId,
     authToken,
@@ -445,7 +480,7 @@ export default function GenotypeRenderer() {
     if (!(config instanceof Object)){
       config = {
         domParent: config,  // Position for domParent
-        server, matrixId, mapId, authToken,
+        baseURL, matrixId, mapId, authToken,
         minGenotypeAutoWidth, minOverviewAutoWidth,
       };
       config.width = (width !== undefined) ? width : null;
@@ -711,13 +746,18 @@ export default function GenotypeRenderer() {
   }
 
   function populateTraitSelect() {
-    const traitSelect = document.getElementById('sortTraitSelect');
+    const sortTraitSelect = document.getElementById('sortTraitSelect');
+    const displayTraitSelect = document.getElementById('displayTraitSelect');
 
     dataSet.traitNames.forEach(name => {
       const opt = document.createElement('option');
       opt.value = name;
       opt.text = name;
-      traitSelect.add(opt);
+      sortTraitSelect.add(opt);
+
+      const clone = opt.cloneNode(true);
+      clone.selected = true;
+      displayTraitSelect.add(clone);
     });
   }
 

--- a/src/flapjack-bytes.js
+++ b/src/flapjack-bytes.js
@@ -465,7 +465,9 @@ export default function GenotypeRenderer() {
   }
 
   genotypeRenderer.renderGenotypesBrapi = function renderGenotypesBrapi(
-    domParent,
+    config,  // Compatibility positional domParent
+
+    // Positional arguments kept for compatibility
     width,
     height,
     baseURL,
@@ -493,10 +495,10 @@ export default function GenotypeRenderer() {
     createRendererComponents(config, false);
     let germplasmData;
 
-    const client = axios.create({ baseURL: config.server });
+    const client = axios.create({ baseURL: config.baseURL });
     client.defaults.headers.common.Authorization = `Bearer ${config.authToken}`;
 
-    if (mapId !== null) {
+    if (config.mapId !== null) {
       // TODO: GOBii don't have the markerpositions call implemented yet so I
       // can't load map data
       processMarkerPositionsCall(client, `/markerpositions?mapDbId=${config.mapId}`)

--- a/src/flapjack-bytes.js
+++ b/src/flapjack-bytes.js
@@ -127,14 +127,6 @@ export default function GenotypeRenderer() {
     const exportTab = createExportTab(config);
     const displayTab = createDisplayTab(config);
 
-    const maxTabHeight = Math.max(
-      controlTab.getBoundingClientRect().height,
-      colorTab.getBoundingClientRect().height,
-      sortTab.getBoundingClientRect().height,
-      exportTab.getBoundingClientRect().height,
-      displayTab.getBoundingClientRect().height
-    );
-
     // Create the tab toggles
     const menuRow = document.createElement('div');
 

--- a/src/flapjack-bytes.js
+++ b/src/flapjack-bytes.js
@@ -429,10 +429,16 @@ export default function GenotypeRenderer() {
       paletteSelectColor.style.display = 'block';
       paletteSelectColor.setAttribute('type', 'color');
 
+      const paletteResetButton = document.createElement('button');
+      const paletteResetLegend = document.createTextNode("Reset this trait's colors");
+      paletteResetButton.appendChild(paletteResetLegend);
+      paletteResetButton.id = 'paletteReset';
+
       paletteSelectContainer.appendChild(paletteSelectLegend);
       paletteSelectContainer.appendChild(paletteSelectTrait);
       paletteSelectContainer.appendChild(paletteSelectValue);
       paletteSelectContainer.appendChild(paletteSelectColor);
+      paletteSelectContainer.appendChild(paletteResetButton);
 
       tab.appendChild(traitSelectContainer);
       tab.appendChild(paletteSelectContainer);

--- a/src/flapjack-bytes.js
+++ b/src/flapjack-bytes.js
@@ -35,7 +35,7 @@ export default function GenotypeRenderer() {
 
   function sendEvent(eventName, domParent) {
     // TODO: Invesitgate using older event emitting code for IE support
-    const canvasHolder = document.getElementById(domParent.slice(1));
+    const canvasHolder = document.getElementById(domParent.replace('#', ''));
 
     // Create the event.
     const event = new Event(eventName);
@@ -53,7 +53,7 @@ export default function GenotypeRenderer() {
   }
 
   function clearParent(domParent) {
-    const canvasHolder = document.getElementById(domParent.slice(1));
+    const canvasHolder = document.getElementById(domParent.replace('#', ''));
     while (canvasHolder.firstChild){
       canvasHolder.removeChild(canvasHolder.firstChild);
     }
@@ -64,7 +64,7 @@ export default function GenotypeRenderer() {
     if (config.minGenotypeAutoWidth === undefined) config.minGenotypeAutoWidth = 0;
     if (config.minOverviewAutoWidth === undefined) config.minOverviewAutoWidth = 0;
 
-    const canvasHolder = document.getElementById(config.domParent.slice(1));
+    const canvasHolder = document.getElementById(config.domParent.replace('#', ''));
     canvasHolder.style.fontFamily = 'system-ui';
     canvasHolder.style.fontSize = '14px';
     
@@ -333,7 +333,7 @@ export default function GenotypeRenderer() {
     addRadioButton('selectedSort', 'alphabeticSort', 'Alphabetically', false, radioCol);
     addRadioButton('selectedSort', 'similaritySort', 'By similarity to line', false, radioCol, lineSelect);
 
-    if ((config.phenotypeFileDom !== undefined && document.getElementById(config.phenotypeFileDom.slice(1)).files[0] !== undefined) || config.phenotypeFileURL !== undefined){
+    if ((config.phenotypeFileDom !== undefined && document.getElementById(config.phenotypeFileDom.replace('#', '')).files[0] !== undefined) || config.phenotypeFileURL !== undefined){
       const traitSelect = document.createElement('select');
       traitSelect.id = 'sortTraitSelect';
       traitSelect.disabled = true;
@@ -389,7 +389,7 @@ export default function GenotypeRenderer() {
   }
 
   function createDisplayTab(config){
-    if ((config.phenotypeFileDom !== undefined && document.getElementById(config.phenotypeFileDom.slice(1)).files[0] !== undefined) || config.phenotypeFileURL !== undefined){
+    if ((config.phenotypeFileDom !== undefined && document.getElementById(config.phenotypeFileDom.replace('#', '')).files[0] !== undefined) || config.phenotypeFileURL !== undefined){
       const tab = document.createElement('div');
       tab.classList.add('bytes-tab');
 
@@ -852,7 +852,7 @@ export default function GenotypeRenderer() {
     let loadingPromises = [];
 
     if (config.mapFileDom !== undefined){
-      const mapFile = document.getElementById(config.mapFileDom.slice(1)).files[0];
+      const mapFile = document.getElementById(config.mapFileDom.replace('#', '')).files[0];
       let mapPromise = loadFromFile(mapFile);
 
        // Load map data
@@ -868,7 +868,7 @@ export default function GenotypeRenderer() {
     }
 
     if (config.phenotypeFileDom !== undefined){
-      const phenotypeFile = document.getElementById(config.phenotypeFileDom.slice(1)).files[0];
+      const phenotypeFile = document.getElementById(config.phenotypeFileDom.replace('#', '')).files[0];
       let phenotypePromise = loadFromFile(phenotypeFile);
 
       // Load phenotype data
@@ -886,7 +886,7 @@ export default function GenotypeRenderer() {
     }
 
     // const qtlPromise = loadFromFile(qtlFileDom);
-    const genotypeFile = document.getElementById(config.genotypeFileDom.slice(1)).files[0];
+    const genotypeFile = document.getElementById(config.genotypeFileDom.replace('#', '')).files[0];
     let genotypePromise = loadFromFile(genotypeFile);
     loadingPromises.push(genotypePromise);
 

--- a/src/flapjack-bytes.js
+++ b/src/flapjack-bytes.js
@@ -265,7 +265,7 @@ export default function GenotypeRenderer() {
     const radioCol = document.createElement('div');
     radioCol.classList.add('col');
     addRadioButton('selectedScheme', 'nucleotideScheme', 'Nucleotide', true, radioCol);
-    addRadioButton('selectedScheme', 'similarityScheme', 'Similarity to line', false, radioCol, lineSelect);
+    addRadioButton('selectedScheme', 'similarityScheme', 'Similarity to line (allele match)', false, radioCol, lineSelect);
 
     fieldset.appendChild(legend);
     fieldset.appendChild(radioCol);

--- a/src/flapjack-bytes.js
+++ b/src/flapjack-bytes.js
@@ -393,7 +393,10 @@ export default function GenotypeRenderer() {
       const tab = document.createElement('div');
       tab.classList.add('bytes-tab');
 
-      const traitSelectLegend = document.createElement('div');
+      const traitSelectContainer = document.createElement('div');
+      traitSelectContainer.style.float = 'left';
+
+      const traitSelectLegend = document.createElement('p');
       const traitSelectLegendText = document.createTextNode('Traits to display');
       traitSelectLegend.appendChild(traitSelectLegendText);
 
@@ -402,8 +405,37 @@ export default function GenotypeRenderer() {
       traitSelect.multiple = true;
       traitSelect.size = 5;
 
-      tab.appendChild(traitSelectLegend);
-      tab.appendChild(traitSelect);
+      traitSelectContainer.appendChild(traitSelectLegend);
+      traitSelectContainer.appendChild(traitSelect);
+
+      const paletteSelectContainer = document.createElement('div');
+      paletteSelectContainer.style.float = 'left';
+      paletteSelectContainer.style.marginLeft = '10px';
+
+      const paletteSelectLegend = document.createElement('p');
+      const paletteSelectLegendText = document.createTextNode('Trait colors');
+      paletteSelectLegend.appendChild(paletteSelectLegendText);
+
+      const paletteSelectTrait = document.createElement('select');
+      paletteSelectTrait.id = 'paletteTrait'
+      paletteSelectTrait.style.display = 'block';
+
+      const paletteSelectValue = document.createElement('select');
+      paletteSelectValue.id = 'paletteValue';
+      paletteSelectValue.style.display = 'block';
+
+      const paletteSelectColor = document.createElement('input');
+      paletteSelectColor.id = 'paletteColor';
+      paletteSelectColor.style.display = 'block';
+      paletteSelectColor.setAttribute('type', 'color');
+
+      paletteSelectContainer.appendChild(paletteSelectLegend);
+      paletteSelectContainer.appendChild(paletteSelectTrait);
+      paletteSelectContainer.appendChild(paletteSelectValue);
+      paletteSelectContainer.appendChild(paletteSelectColor);
+
+      tab.appendChild(traitSelectContainer);
+      tab.appendChild(paletteSelectContainer);
       
       return tab;
     }

--- a/src/sort/AlphabeticLineSort.js
+++ b/src/sort/AlphabeticLineSort.js
@@ -10,8 +10,4 @@ export default class AlphabeticLineSort {
       a.name < b.name ? -1 : (
         a.name > b.name ? 1 : 0)));
   }
-
-  setChromosomes(chromosomeIndices){
-    
-  }
 }

--- a/src/sort/ImportingOrderLineSort.js
+++ b/src/sort/ImportingOrderLineSort.js
@@ -8,8 +8,4 @@ export default class ImportingOrderLineSort {
   sort(dataSet){
     dataSet.germplasmList.sort((a, b) => dataSet.importingOrder.indexOf(a.name) - dataSet.importingOrder.indexOf(b.name));
   }
-
-  setChromosomes(chromosomeIndices){
-    
-  }
 }

--- a/src/sort/TraitLineSort.js
+++ b/src/sort/TraitLineSort.js
@@ -1,0 +1,29 @@
+
+
+export default class TraitLineSort {
+  constructor (traitName){
+    this.hasScore = false;
+    this.traitName = traitName;
+  }
+
+  sort(dataSet){
+    const self = this;
+    const trait = dataSet.getTrait(self.traitName);
+    dataSet.germplasmList.sort(function (a, b){
+      if (a.phenotype === undefined) return 1;
+      if (b.phenotype === undefined) return -1;
+      const valueA = a.getPhenotype(self.traitName);  // No need to getValue, the valueIndex are already sorted for category traits
+      if (valueA === undefined) return 1;
+      const valueB = b.getPhenotype(self.traitName);
+      if (valueB === undefined) return -1;
+      if (valueA < valueB) return -1;
+      if (valueB < valueA) return 1;
+      if (valueA == valueB) return 0;
+    });
+  }
+
+
+  setTrait(traitName){
+    this.traitName = traitName;
+  }
+}


### PR DESCRIPTION
This pull request aims at porting the traits features, and support of .phenotype files, to Flapjack-Bytes.
It includes :

- New, cleaner system to pass parameters
	- Parameters were formerly passed as ordered arguments to a method, that, while being sufficient for the basic features Flapjack-Bytes had, is now cluttered and cumbersome as new features get added. Futhermore, ordered arguments need to stay in the same order to keep backwards compatibility, so adding new features leads to a more and more anarchic parameter list.
	- Hence the need for a more sophisticated arguments system. Parameters are now passed in a rather standard way, as a JSON object with named parameters, as described in the Readme. This allows more readability, maintenability and scalability in the future.
	- The former way to pass arguments, as ordered parameters, is still available for backwards compatibility but does not include the new features added in this contribution.
	- For example :

```javascript
renderer.renderGenotypesUrl({
    domParent: "#canvas-holder",
    width: 800,
    height: 600,
    mapFileURL: document.getElementById('mapfile').value,
    genotypeFileURL: document.getElementById('genofile').value,
    phenotypeFileURL: document.getElementById('phenofile').value,
    overviewWidth: 800,
    overviewHeight: 200,
    dataSetId: "MyDataSet",
});
```

- Support of Flapjack's .phenotype files
	- Flapjack-Bytes can now import standard Flapjack's .phenotype files, and display traits in a similar fashion Flapjack does
	- Trait values and color gradients are displayed in front of each sample when available
	- It is now possible to sort by a trait's values
	- The traits to display are configurable, and color gradients can be set manually (like when one needs a coherent color scheme between several tools)
	- Add mouse-over text boxes to state the trait it is on. This has also been added for the sorting score.

- User settings are now saved in localStorage
	- If the `saveSettings` parameter is set to `true` (currently, it is by default), user settings like the color scheme, sorting option and trait colors are saved in localStorage to have them readily available. Those settings are specific to the data set, as far as Flapjack-Bytes can tell
	- By default, the user settings are saved under an identifier given by the data origin (.genotype file name or URL, BrAPI matrix ID)
	- The optional parameter `dataSetId` allows to supply a custom identifier to save the user settings under — it means that regardless of the file name / URL / matrix ID, any data set associated to the same identifier will load the same settings. This is especially useful for applications that integrate Flapjack-Bytes and may give it incoherent file names or URL for the same data set (or for subsets of the same data set) — for example temporary URLs, different file names for subsets, ...

- User interface overhaul
	- The UI was formerly constituted of fieldsets stacked below the canvas. This was sufficient at the time, but more and more inconvenient as new features got added, especially when not using Bootstrap.
	- All controls have thus been folded in a set of tabs above the canvas, for easier access (that is, not having to scroll all the way down every time an option needs to be changed), better organisation, better scalability and to reduce cluttering.

- Minor enhancements and fixes
	- Visibly disable the interface while Flapjack-Bytes is processing data (like when changing the sorting option), to prevent it from appearing frozen
	- Remove the dependency to jQuery in the examples and documentation
	- The leading '#' is no longer needed in DOM id parameters (parent div, file inputs), but is still optional for backwards compatibility or readability purposes.

![image](https://user-images.githubusercontent.com/71443252/148947357-f2ccdac9-d8e7-48c1-a9d0-cb51def4d987.png)
